### PR TITLE
Use each-async instead of async

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "svgo": "~0.4.1",
     "filesize": "~2.0.0",
-    "chalk": "~0.3.0",
-    "async": "~0.2.9"
+    "chalk": "~0.4.0",
+    "each-async": "~0.1.2"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -1,6 +1,6 @@
 'use strict';
 var chalk = require('chalk');
-var async = require('async');
+var eachAsync = require('each-async');
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('svgmin', 'Minify SVG', function () {
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
 		var svgo = new (require('svgo'))(options);
 		var filesize = require('filesize');
 
-		async.each(this.files, function (el, next) {
+		eachAsync(this.files, function (el, index, next) {
 			var svgin = grunt.file.read(el.src + '');
 			svgo.optimize(svgin, function (result) {
 				if (result.error) {


### PR DESCRIPTION
I agree to the design concept of [each-async](https://github.com/sindresorhus/each-async):

> I often use `async.each()` for doing async operations when iterating, but I almost never use the other gadzillion methods in `async`.
