### PR TITLE
Bumped SVGO dependency to ^0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "each-async": "^1.0.0",
     "log-symbols": "^1.0.0",
     "pretty-bytes": "^1.0.1",
-    "svgo": "^0.4.5"
+    "svgo": "^0.5.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Needed this for the added removeDesc plugin.
