### PR TITLE
Fix the svgo error message outputting

### DIFF
--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -17,7 +17,7 @@ module.exports = function (grunt) {
 
 			svgo.optimize(srcSvg, function (result) {
 				if (result.error) {
-					grunt.warn('Error parsing SVG:', result.error);
+					grunt.warn('Error parsing SVG: ' + result.error);
 					next();
 					return;
 				}


### PR DESCRIPTION
The second parameter of `grunt.warn` is an error code, not additional output like `console.log`. Currently it doesn't output the svgo error message at all.

http://gruntjs.com/api/grunt.fail#grunt.fail.warn