### PR TITLE
hide per-file logs by default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ plugins: [
 
 Check each plugin for `exports.params` to see if it has default parameters and what they are.
 
+In verbose mode grunt task will print per-file savings.
 
 ## License
 

--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -10,6 +10,7 @@ module.exports = function (grunt) {
 		var done = this.async();
 		var svgo = new SVGO(this.options());
 		var totalSaved = 0;
+		var noVerbose = this.options().noVerbose || false;
 
 		eachAsync(this.files, function (el, i, next) {
 			var srcPath = el.src[0];
@@ -26,7 +27,9 @@ module.exports = function (grunt) {
 				var percentage = saved / srcSvg.length * 100;
 				totalSaved += saved;
 
-				grunt.log.writeln(logSymbols.success + ' ' + srcPath + chalk.gray(' (saved ' + chalk.bold(prettyBytes(saved)) + ' ' + Math.round(percentage) + '%)'));
+				if (!noVerbose) {
+					grunt.log.writeln(logSymbols.success + ' ' + srcPath + chalk.gray(' (saved ' + chalk.bold(prettyBytes(saved)) + ' ' + Math.round(percentage) + '%)'));
+				}
 				grunt.file.write(el.dest, result.data);
 				next();
 			});

--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -10,7 +10,6 @@ module.exports = function (grunt) {
 		var done = this.async();
 		var svgo = new SVGO(this.options());
 		var totalSaved = 0;
-		var noVerbose = this.options().noVerbose || false;
 
 		eachAsync(this.files, function (el, i, next) {
 			var srcPath = el.src[0];
@@ -27,9 +26,7 @@ module.exports = function (grunt) {
 				var percentage = saved / srcSvg.length * 100;
 				totalSaved += saved;
 
-				if (!noVerbose) {
-					grunt.log.writeln(logSymbols.success + ' ' + srcPath + chalk.gray(' (saved ' + chalk.bold(prettyBytes(saved)) + ' ' + Math.round(percentage) + '%)'));
-				}
+				grunt.verbose.writeln(logSymbols.success + ' ' + srcPath + chalk.gray(' (saved ' + chalk.bold(prettyBytes(saved)) + ' ' + Math.round(percentage) + '%)'));
 				grunt.file.write(el.dest, result.data);
 				next();
 			});


### PR DESCRIPTION
For large number of svg files logs become huge, so we need an option to reduce output