### PR TITLE
Fix filename prefix issue

### DIFF
--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -14,7 +14,7 @@ module.exports = grunt => {
 			const sourcePath = element.src[0];
 			const sourceSvg = grunt.file.read(sourcePath);
 
-			const result = await svgo.optimize(sourceSvg, {srcPath: sourcePath});
+			const result = await svgo.optimize(sourceSvg, {path: sourcePath});
 			if (result.error) {
 				grunt.warn(`${sourcePath}: ${result.error}`);
 				return;


### PR DESCRIPTION
Due to this bug, all SVG files that go through the `prefixIds` plugin are prefixed with the default "prefix", regardless of filename. This was a game-breaking bug for me that I spent like 3 hours trying to track down...


Fixes #61